### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import {
 
 ### constructor
 #### PriorityQueue
-constructor requires a compare function that works similar to javascript sort callback, returning a number bigger than 0, means swap elemens.
+constructor requires a compare function that works similar to javascript sort callback, returning a number bigger than 0, means swap elements.
 
 ##### TS
 ```ts


### PR DESCRIPTION
Typo correction under `PriorityQueue` constructor description denoted as "elemens".
## Correction Visual
![Screen Shot 2022-04-12 at 4 06 01 PM](https://user-images.githubusercontent.com/67129197/163045088-9f139582-80c4-48c9-807b-1bc2c0c90ac0.png)


