### PR TITLE
[v5] Add .from method to MaxPriorityQueue and MinPriorityQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A performant priority queue implementation using a Heap data structure.
 * [import](#import)
 * [API](#api)
   * [constructor](#constructor)
+  * [.from](#fromentries)
   * [.enqueue](#enqueue)
   * [.front](#front)
   * [.back](#back)
@@ -127,6 +128,30 @@ interface Bid {
 const biddersQueue = new MaxPriorityQueue<Bid>({
   priority: (bid: Bid) => bid.value
 });
+```
+
+### from(entries)
+
+Creates a priority queue from an array of element-priority pairs.
+
+```js
+MaxPriorityQueue.from([
+  ['Alice', 19],
+  ['Bob', 18],
+  ['Charles', 20]
+])
+// { priority: 20, element: 'Charles' }, 
+// { priority: 19, element: 'Alice' }, 
+// { priority: 18, element: 'Bob' }
+
+MinPriorityQueue.from([
+  ['Alice', 19],
+  ['Bob', 18],
+  ['Charles', 20]
+])
+// { priority: 18, element: 'Bob' },
+// { priority: 19, element: 'Alice' }, 
+// { priority: 20, element: 'Charles' },
 ```
 
 ### .enqueue

--- a/src/maxPriorityQueue.d.ts
+++ b/src/maxPriorityQueue.d.ts
@@ -1,3 +1,7 @@
-import { PriorityQueue } from './priorityQueue';
+import { PriorityQueue } from "./priorityQueue";
 
-export class MaxPriorityQueue<T> extends PriorityQueue<T> {}
+export class MaxPriorityQueue<T> extends PriorityQueue<T> {
+  static from(
+    entries: readonly Iterable<readonly [element: T, priority: number]>
+  ): MaxPriorityQueue<T>;
+}

--- a/src/maxPriorityQueue.js
+++ b/src/maxPriorityQueue.js
@@ -17,6 +17,16 @@ class MaxPriorityQueue extends PriorityQueue {
       this._heap = new MaxHeap();
     }
   }
+
+  static from(entries) {
+    const queue = new MaxPriorityQueue();
+
+    for (const [element, priority] of entries) {
+      queue.enqueue(element, priority)
+    }
+    
+    return queue;
+  }
 }
 
 exports.MaxPriorityQueue = MaxPriorityQueue;

--- a/src/minPriorityQueue.d.ts
+++ b/src/minPriorityQueue.d.ts
@@ -1,3 +1,7 @@
 import { PriorityQueue } from './priorityQueue';
 
-export class MinPriorityQueue<T> extends PriorityQueue<T> {}
+export class MinPriorityQueue<T> extends PriorityQueue<T> {
+    static from(
+      entries: readonly Iterable<readonly [element: T, priority: number]>
+    ): MaxPriorityQueue<T>;
+}

--- a/src/minPriorityQueue.js
+++ b/src/minPriorityQueue.js
@@ -17,6 +17,16 @@ class MinPriorityQueue extends PriorityQueue {
       this._heap = new MinHeap();
     }
   }
+
+  static from(entries) {
+    const queue = new MinPriorityQueue();
+
+    for (const [element, priority] of entries) {
+      queue.enqueue(element, priority)
+    }
+    
+    return queue;
+  }
 }
 
 exports.MinPriorityQueue = MinPriorityQueue;

--- a/test/maxPriorityQueue.test.js
+++ b/test/maxPriorityQueue.test.js
@@ -269,5 +269,30 @@ describe('MaxPriorityQueue tests', () => {
         expect(employeesQueue.dequeue()).to.equal(null);
       });
     });
+
+    describe('MaxPriorityQueue.from(entries)', () => {
+      it('should create MaxPriorityQueue from [element, priority] pair array', () => {
+        const numValues = [
+          { id: 50 },
+          { id: 80 },
+          { id: 30 },
+          { id: 90 },
+          { id: 60 },
+          { id: 40 },
+          { id: 20 }
+        ];
+
+        const q = MaxPriorityQueue.from(numValues.map((element) => [element, element.id]));
+        expect(q.toArray()).to.deep.equal([
+          { priority: 90, element: { id: 90 } },
+          { priority: 80, element: { id: 80 } },
+          { priority: 60, element: { id: 60 } },
+          { priority: 50, element: { id: 50 } },
+          { priority: 40, element: { id: 40 } },
+          { priority: 30, element: { id: 30 } },
+          { priority: 20, element: { id: 20 } }
+        ]);
+      });
+    });
   });
 });

--- a/test/minPriorityQueue.test.js
+++ b/test/minPriorityQueue.test.js
@@ -289,5 +289,30 @@ describe('MinPriorityQueue tests', () => {
         expect(employeesQueue.dequeue()).to.equal(null);
       });
     });
+
+    describe('MinPriorityQueue.from(entries)', () => {
+      it('should create MinPriorityQueue from [element, priority] pair array', () => {
+        const numValues = [
+          { id: 50 },
+          { id: 80 },
+          { id: 30 },
+          { id: 90 },
+          { id: 60 },
+          { id: 40 },
+          { id: 20 }
+        ];
+
+        const q = MinPriorityQueue.from(numValues.map((element) => [element, element.id]));
+        expect(q.toArray()).to.deep.equal([
+          { priority: 20, element: { id: 20 } },
+          { priority: 30, element: { id: 30 } },
+          { priority: 40, element: { id: 40 } },
+          { priority: 50, element: { id: 50 } },
+          { priority: 60, element: { id: 60 } },
+          { priority: 80, element: { id: 80 } },
+          { priority: 90, element: { id: 90 } }
+        ]);
+      });
+    });
   });
 });


### PR DESCRIPTION
`.from` static method creates a priority queue from an array of element-priority pairs.

```js
const entries = [
  ['Alice', 18],
  ['Bob', 19],
  ['Charles', 20]
]

MaxPriorityQueue.from(entries).toArray() // [{ priority: 20, element: 'Charles' }, { priority: 19, element: 'Bob' }, { priority: 18, element: 'Alice' }]
```
