### PR TITLE
Capture null returns in type definitions

### DIFF
--- a/src/maxPriorityQueue.d.ts
+++ b/src/maxPriorityQueue.d.ts
@@ -5,12 +5,12 @@ export class MaxPriorityQueue<T> {
   [Symbol.iterator](): Iterator<T, any, undefined>;
   size(): number;
   isEmpty(): boolean;
-  front(): T;
-  back(): T;
+  front(): T | null;
+  back(): T | null;
   enqueue(value: T): MaxPriorityQueue<T>;
   push(value: T): MaxPriorityQueue<T>;
-  dequeue(): T;
-  pop(): T;
+  dequeue(): T | null;
+  pop(): T | null;
   remove(cb: (value: T) => boolean): T[];
   contains(cb: (value: T) => boolean): boolean;
   toArray(): T[];

--- a/src/minPriorityQueue.d.ts
+++ b/src/minPriorityQueue.d.ts
@@ -5,12 +5,12 @@ export class MinPriorityQueue<T> {
   [Symbol.iterator](): Iterator<T, any, undefined>;
   size(): number;
   isEmpty(): boolean;
-  front(): T;
-  back(): T;
+  front(): T | null;
+  back(): T | null;
   enqueue(value: T): MinPriorityQueue<T>;
   push(value: T): MinPriorityQueue<T>;
-  dequeue(): T;
-  pop(): T;
+  dequeue(): T | null;
+  pop(): T | null;
   remove(cb: (value: T) => boolean): T[];
   contains(cb: (value: T) => boolean): boolean;
   toArray(): T[];

--- a/src/priorityQueue.d.ts
+++ b/src/priorityQueue.d.ts
@@ -5,12 +5,12 @@ export class PriorityQueue<T> {
   [Symbol.iterator](): Iterator<T, any, undefined>;
   size(): number;
   isEmpty(): boolean;
-  front(): T;
-  back(): T;
+  front(): T | null;
+  back(): T | null;
   enqueue(value: T): PriorityQueue<T>;
   push(value: T): PriorityQueue<T>;
-  dequeue(): T;
-  pop(): T;
+  dequeue(): T | null;
+  pop(): T | null;
   remove(cb: (value: T) => boolean): T[];
   contains(cb: (value: T) => boolean): boolean;
   toArray(): T[];


### PR DESCRIPTION
Hey @eyas-ranjous, I noticed the same issue in this library that [PR 35](https://github.com/datastructures-js/heap/pull/35) fixed in the `datastructures-js/heap` dependency.

Hopefully not too controversial!