### PR TITLE
refactor(types): Make the queue generate the correct instance type ba…

### DIFF
--- a/src/maxPriorityQueue.d.ts
+++ b/src/maxPriorityQueue.d.ts
@@ -1,7 +1,25 @@
-import { PriorityQueue } from "./priorityQueue";
+import {
+  PriorityQueue,
+  PriorityQueueConstructor,
+  PriorityQueueOptions,
+  PriorityQueueItem,
+} from "./priorityQueue";
 
-export class MaxPriorityQueue<T> extends PriorityQueue<T> {
-  static from(
-    entries: readonly Iterable<readonly [element: T, priority: number]>
+interface MaxPriorityQueue<E, T = E> extends PriorityQueue<E, T> {}
+
+interface MaxPriorityQueueConstructor extends PriorityQueueConstructor {
+  new <T>(
+    options: PriorityQueueOptions<T> &
+      Required<Pick<PriorityQueueOptions<T>, "compare">>
+  ): MaxPriorityQueue<T>;
+  new <T>(options?: PriorityQueueOptions<T>): MaxPriorityQueue<
+    T,
+    PriorityQueueItem<T>
+  >;
+
+  from<T>(
+    entries: Iterable<readonly [element: T, priority: number]>
   ): MaxPriorityQueue<T>;
 }
+
+declare var MaxPriorityQueue: MaxPriorityQueueConstructor;

--- a/src/minPriorityQueue.d.ts
+++ b/src/minPriorityQueue.d.ts
@@ -1,7 +1,25 @@
-import { PriorityQueue } from './priorityQueue';
+import {
+  PriorityQueue,
+  PriorityQueueConstructor,
+  PriorityQueueOptions,
+  PriorityQueueItem,
+} from "./priorityQueue";
 
-export class MinPriorityQueue<T> extends PriorityQueue<T> {
-    static from(
-      entries: readonly Iterable<readonly [element: T, priority: number]>
-    ): MinPriorityQueue<T>;
+interface MinPriorityQueue<E, T = E> extends PriorityQueue<E, T> {}
+
+interface MinPriorityQueueConstructor extends PriorityQueueConstructor {
+  new <T>(
+    options: PriorityQueueOptions<T> &
+      Required<Pick<PriorityQueueOptions<T>, "compare">>
+  ): MinPriorityQueue<T>;
+  new <T>(options?: PriorityQueueOptions<T>): MinPriorityQueue<
+    T,
+    PriorityQueueItem<T>
+  >;
+
+  from<T>(
+    entries: Iterable<readonly [element: T, priority: number]>
+  ): MinPriorityQueue<T>;
 }
+
+declare var MinPriorityQueue: MinPriorityQueueConstructor;

--- a/src/priorityQueue.d.ts
+++ b/src/priorityQueue.d.ts
@@ -8,14 +8,22 @@ export interface PriorityQueueItem<T> {
   element: T;
 }
 
-export abstract class PriorityQueue<T> {
-  constructor(options?: PriorityQueueOptions<T>);
+interface PriorityQueue<E, T = E> {
   size(): number;
   isEmpty(): boolean;
-  front(): PriorityQueueItem<T> | null;
-  back(): PriorityQueueItem<T> | null;
-  enqueue(element: T, priority?: number): PriorityQueue<T>;
-  dequeue(): PriorityQueueItem<T> | null;
-  toArray(): PriorityQueueItem<T>[];
+  front(): T | null;
+  back(): T | null;
+  enqueue(element: E, priority?: number): PriorityQueue<E, T>;
+  dequeue(): T | null;
+  toArray(): T[];
   clear(): void;
 }
+
+interface PriorityQueueConstructor {
+  new <T>(
+    options: PriorityQueueOptions<T> &
+      Required<Pick<PriorityQueueOptions<T>, "compare">>
+  ): PriorityQueue<T>;
+}
+
+declare var PriorityQueue: PriorityQueueConstructor;


### PR DESCRIPTION
Hey @eyas-ranjous 

In V5, I noticed that the queue element types don't match the actual types when `compare` is set.
So, I have attempted to fix it. Hopefully, this change resolves the issue as intended.

