### PR TITLE
remove v4/v5 description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ A heap-based implementation of priority queue in javascript with typescript supp
 <img src="https://user-images.githubusercontent.com/6517308/121813242-859a9700-cc6b-11eb-99c0-49e5bb63005b.jpg">
 
 
-#### NOTE: LeetCode is using previous versions of the lib [here](https://support.leetcode.com/hc/en-us/articles/360011833974-What-are-the-environments-for-the-programming-languages-). I am maintaining v4 & v5 for this purpose
-- [v4](https://github.com/datastructures-js/priority-queue/tree/v4)
-- [v5](https://github.com/datastructures-js/priority-queue/tree/v5)
-
 # Contents (v6)
 * [Install](#install)
 * [require](#require)


### PR DESCRIPTION
leetcode has already switch to priority-queue v6, so i think it's safe to remove the v4/v5 description now.

ref: https://support.leetcode.com/hc/en-us/articles/360011833974-What-are-the-environments-for-the-programming-languages-